### PR TITLE
Fix profile switching from mouse buttons

### DIFF
--- a/Sources/NagaController/AppDelegate.swift
+++ b/Sources/NagaController/AppDelegate.swift
@@ -6,6 +6,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let popover = NSPopover()
     private let eventTapManager = EventTapManager.shared
     private var batteryObserver: NSObjectProtocol?
+    private var profileObserver: NSObjectProtocol?
     private var didAlertLowBattery = false
     private var useEmojiInStatus = false
 
@@ -60,6 +61,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.handleBatteryUpdate()
         }
         // Initialize status item text
+        profileObserver = NotificationCenter.default.addObserver(
+            forName: ConfigManager.profileDidChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.updateStatusItemBattery(level: BatteryMonitor.shared.batteryLevel)
+        }
         updateStatusItemBattery(level: BatteryMonitor.shared.batteryLevel)
 
         // Start event tap based on persisted setting
@@ -69,6 +75,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         eventTapManager.stop()
+        if let profileObserver { NotificationCenter.default.removeObserver(profileObserver) }
     }
 
     @objc private func togglePopover(_ sender: Any?) {
@@ -103,12 +110,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func updateStatusItemBattery(level: Int?) {
         guard let button = statusItem.button else { return }
         let hasImage = (button.image != nil)
+        let profile = ConfigManager.shared.currentProfileName
         if let lvl = level {
-            button.title = (hasImage ? " " : "🖱️ ") + "\(lvl)%"
-            button.toolTip = "Naga battery: \(lvl)%"
+            button.title = (hasImage ? " " : "🖱️ ") + "\(lvl)% · \(profile)"
+            button.toolTip = "Naga battery: \(lvl)% · Profile: \(profile)"
         } else {
-            button.title = hasImage ? "" : "🖱️"
-            button.toolTip = "Naga battery: —"
+            button.title = (hasImage ? " " : "🖱️ ") + profile
+            button.toolTip = "Naga battery: — · Profile: \(profile)"
         }
     }
 

--- a/Sources/NagaController/UI/MappingViewController.swift
+++ b/Sources/NagaController/UI/MappingViewController.swift
@@ -30,6 +30,7 @@ final class MappingViewController: NSViewController {
     private var container: NSStackView!
     private var topConstraint: NSLayoutConstraint?
     private var backgroundGradient: CAGradientLayer?
+    private var profileObserver: NSObjectProtocol?
 
     override func loadView() {
         self.view = NSView()
@@ -205,6 +206,20 @@ final class MappingViewController: NSViewController {
         topConstraint?.isActive = true
 
         refreshRows()
+
+        profileObserver = NotificationCenter.default.addObserver(
+            forName: ConfigManager.profileDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshRows()
+        }
+    }
+
+    deinit {
+        if let profileObserver {
+            NotificationCenter.default.removeObserver(profileObserver)
+        }
     }
 
     override func viewDidAppear() {

--- a/Sources/NagaController/Utils/ConfigManager.swift
+++ b/Sources/NagaController/Utils/ConfigManager.swift
@@ -46,6 +46,7 @@ struct ButtonAction: Codable {
 
 final class ConfigManager {
     static let shared = ConfigManager()
+    static let profileDidChangeNotification = Notification.Name("NagaController.profileDidChange")
 
     private(set) var profiles: [String: Profile] = [:]
     private(set) var currentProfileName: String = "Default"
@@ -112,6 +113,7 @@ final class ConfigManager {
         UserDefaults.standard.set(name, forKey: kCurrentProfileKey)
         ButtonMapper.shared.updateMapping(mappingForCurrentProfile())
         ButtonMapper.shared.updateHypershiftMapping(hypershiftMappingForCurrentProfile())
+        NotificationCenter.default.post(name: ConfigManager.profileDidChangeNotification, object: self)
     }
 
     func getRemappingEnabled() -> Bool {


### PR DESCRIPTION
Profile actions could be saved, but pressing the assigned button only wrote a log message. The active profile did not change.

This change applies the selected profile and updates the mapping window and menu bar to show it.

The fix was tested in a local build with a Naga V2 HyperSpeed over Bluetooth. Shortcut actions and switching between three profiles worked after granting permissions and restarting the app. The clean contribution build also compiles with the macOS 15.4 SDK. Automated tests could not run because XCTest is not available in the local Command Line Tools installation.