### PR TITLE
Add a setup guide for profiles and DPI buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A macOS menu bar app to remap the 12 side buttons of the Razer Naga V2 Hyperspee
 
 ### First run setup
 
-See the [user guide](USER-GUIDE.md) for shortcuts, profile switching, permissions, and a tested DPI button setup.
+See the [user guide](USER-GUIDE.md) for shortcuts, profile switching, Hypershift, permissions, and a tested DPI button setup.
 
 1. Click the menu bar icon → turn ON "Enable remapping"
 2. Click "Configure mappings…" to set actions for buttons 1–12
@@ -60,9 +60,9 @@ See the [user guide](USER-GUIDE.md) for shortcuts, profile switching, permission
 ## Troubleshooting
 
 1. Grant Accessibility permissions (System Settings → Privacy & Security → Accessibility) and ensure the app is checked
-2. Launch from Terminal to see diagnostics:
+2. Launch from Terminal to see diagnostics (launch through `open`; running the binary directly makes macOS kill the app on its first Bluetooth access):
    ```bash
-   ./NagaController.app/Contents/MacOS/NagaController
+   open --stdout /tmp/naga.log --stderr /tmp/naga.log ./NagaController.app && tail -f /tmp/naga.log
    ```
 3. Turn ON "Enable remapping" in the menu bar popover
 4. Expected logs:
@@ -110,7 +110,7 @@ This does not work over the HyperSpeed 2.4GHz dongle — most vendor dongles do 
 bash Scripts/build_app.sh
 
 # Run the app
-./NagaController.app/Contents/MacOS/NagaController
+open ./NagaController.app
 ```
 
 ### Create DMG for distribution

--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ A macOS menu bar app to remap the 12 side buttons of the Razer Naga V2 Hyperspee
 
 ### First run setup
 
+See the [user guide](USER-GUIDE.md) for shortcuts, profile switching, permissions, and a tested DPI button setup.
+
 1. Click the menu bar icon → turn ON "Enable remapping"
 2. Click "Configure mappings…" to set actions for buttons 1–12
 
 ### Permissions
 
 - **Accessibility**: System Settings → Privacy & Security → Accessibility → enable "NagaController"
+- **Input Monitoring**: System Settings → Privacy & Security → Input Monitoring → enable "NagaController", then quit and reopen the app
 - **Bluetooth (battery)**: System Settings → Privacy & Security → Bluetooth → allow "NagaController"
 - **Tip**: Always launch the same `.app` you granted permissions to (avoid running other binaries) so permissions persist
 

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -10,17 +10,23 @@
 
 Saving a mapping does not turn remapping on. If a button still types a number, check the switch in the menu bar first. If access was just granted, restart the app.
 
+## Before you start: reset the mouse's on-board profile
+
+The Naga stores its own button assignments in the mouse. If you ever remapped buttons in Razer Synapse on Windows, those assignments stay active over Bluetooth on the Mac and NagaController will not see the buttons it expects (a side button may type `w`, or act as a middle click). If some buttons do nothing in NagaController, connect the mouse to a Windows machine, open Synapse, reset the on-board profile to defaults, then reconnect it to the Mac. NagaController cannot change the on-board profile itself; Razer only exposes that protocol over USB, never over Bluetooth.
+
 ## Assign a shortcut
 
-Select a profile, click **Edit…** on a button, then choose **Key**. Enter a key such as `c` and select the Command modifier for Copy. Save the action, then use the main **Save** button to save your profiles to disk.
+Select a profile, click **Configure** on a button card, and choose the **Key** tab. Click the capture box and press the shortcut you want (for example ⌘C for Copy), or pick one from **Quick Presets…**. The presets also include bare modifier keys, so a side button can act as Shift or Command on its own. Click **Save**.
 
-The description is only a label. For example, naming an action "Paste" does not make it paste: the shortcut must be Command+V.
+The **Label / Description** field is only a label. Naming an action "Paste" does not make it paste: the shortcut must be ⌘V.
+
+The other tabs are **App** (open an application), **Cmd** (run a shell command), **Text** (type a snippet), **Profile** (switch profiles, see below), **macOS** (media keys, volume, brightness, Mission Control, Show Desktop) and **Hypershift** (see below).
+
+The trash icon on a card clears that button's mapping.
 
 ## Switch profiles with mouse buttons
 
-This requires the [profile-switch fix](https://github.com/DParent10/NagaController/pull/12). Older builds may save a Profile action without applying it when pressed.
-
-Create your profiles under **Manage Profiles**. Edit a button, choose **Profile**, select the target profile, and save.
+Create your profiles under **Manage Profiles**. Configure a button, choose the **Profile** tab, select the target profile, and save. Pressing the button switches the active profile immediately; the mapping window and the menu bar title show the new profile.
 
 For example:
 
@@ -34,26 +40,55 @@ Set these buttons in every profile you want to switch from. They are not global.
 
 Switching a profile changes the button mappings; it does not open or focus an application. Automatic switching based on the active application is not implemented.
 
-## DPI buttons and Back/Forward over Bluetooth
+## Hypershift: a second layer of mappings
 
-On our tested Naga V2 HyperSpeed, mapping DPI Up/Down in NagaController also left the mouse's built-in DPI change active. Blocking the original keys did not prevent the sensitivity change.
+Hypershift gives every button a second action while a chosen button is held or toggled, like Fn on a keyboard.
 
-This setup worked on that mouse:
+1. Configure the button you want as the Hypershift key, choose the **Hypershift** tab, and pick **Hold to Activate** or **Click to Toggle**. Save.
+2. In the mapping window, turn on the **Hypershift** toggle in the top bar. It turns green and the cards now show the Hypershift layer, which starts empty.
+3. Configure the buttons you want on that layer as usual. The editor also has a **Standard Layer / Hypershift Layer** switch at the top, so you can edit both layers of a button in one place.
 
-1. Connect the mouse to a Windows computer using its 2.4 GHz receiver.
-2. In Razer Synapse, select the DPI buttons and assign Back/Forward under **Mouse Function**. The choices may be named **Mouse Button 4** and **Mouse Button 5**. Test the direction instead of relying on the number.
-3. Quit Synapse and check both buttons again.
-4. Power the mouse off and on, switch to Bluetooth, and test on the Mac.
-5. If Back/Forward works without NagaController, leave DPI Up/Down unassigned in NagaController to avoid duplicate actions.
+While Hypershift is active, buttons without a Hypershift mapping fall back to their standard mapping. In toggle mode, holding the Hypershift button for longer than half a second always turns Hypershift off, in case you lose track of its state.
 
-The user confirmed that the assignments continued to work over Bluetooth on their mouse. This is a tested setup, not a guarantee for every Razer model or firmware version.
+## DPI buttons
 
-Razer's [button mapping instructions](https://mysupport.razer.com/app/answers/detail/a_id/6400/) include a requirement to keep Synapse running. Check the behavior on your own mouse before relying on saved assignments.
+The two buttons behind the scroll wheel appear as **DPI Up** and **DPI Down** in the mapping window. They can be mapped like any other button, with one catch.
+
+### Out of the box: mapped action plus a DPI change
+
+With the mouse at its default on-board profile, pressing a DPI button changes the mouse's sensitivity in the mouse itself, and NagaController runs your mapped action as well. Blocking the original keys cannot stop the sensitivity change, because it happens in the mouse firmware, not on the Mac. NagaController actually detects these presses by watching the DPI change, so the first press after launching the app or reconnecting the mouse only records the current DPI and fires nothing.
+
+### Recommended: reassign the DPI buttons in Synapse, then learn them
+
+To use the DPI buttons purely as extra buttons, give them a keyboard key in the on-board profile and let NagaController learn that key. Tested on a Naga V2 HyperSpeed over Bluetooth:
+
+1. Connect the mouse to a Windows computer with its 2.4 GHz receiver and open Razer Synapse.
+2. Assign **F16** to DPI Up and **F17** to DPI Down under **Keyboard Function**. F13 and F14 also work, but macOS treats F14 and F15 as brightness keys, so they dim or brighten the screen whenever NagaController is not running. F16 through F19 have no default function on a Mac.
+3. Quit Synapse, power the mouse off and on, and reconnect it to the Mac over Bluetooth. The DPI buttons no longer change sensitivity.
+4. In NagaController, click **Configure** on the **DPI Up** card, then **Learn Hardware Trigger…** at the bottom of the editor, and press DPI Up on the mouse within a second. The **Trigger:** label changes from "(Default)" to the learned key code. Choose an action and save. Repeat for **DPI Down**.
+
+The learned trigger is tied to the mouse, so the same F-key on a keyboard is left alone. Once learned, NagaController blocks the key and runs your action, so nothing leaks through to other apps.
+
+### Alternative: Back/Forward without NagaController
+
+If all you want from the DPI buttons is browser Back and Forward, assign **Mouse Button 4** and **Mouse Button 5** under **Mouse Function** in Synapse instead, test the direction rather than trusting the numbers, and leave DPI Up and DPI Down unmapped in NagaController. Do not combine this with a NagaController mapping: the app only blocks keyboard events, so a mapped Back/Forward button would run both your action and the browser navigation.
+
+Razer's [button mapping instructions](https://mysupport.razer.com/app/answers/detail/a_id/6400/) mention keeping Synapse running. On the tested mouse the on-board assignments kept working over Bluetooth with Synapse closed, but check the behavior on your own mouse and firmware before relying on it.
+
+## Learn Hardware Trigger for other mice
+
+**Learn Hardware Trigger…** is not limited to the DPI buttons. Any button card can learn a trigger from any mouse whose buttons send a distinct signal, which is how NagaController can support Razer mice other than the Naga. It works best when the button sends a keystroke; buttons that send only a mouse click can currently be learned for the DPI Up and DPI Down cards, but not for the twelve side button cards. Clear a learned trigger with the small ⓧ next to the **Trigger:** label.
 
 ## Updates and saved settings
 
-The standard app stores profiles in `~/Library/Application Support/NagaController/profiles.json`. Back up this file before changing builds.
+The app stores profiles in `~/Library/Application Support/NagaController/profiles.json`. Back up this file before changing builds.
 
-An ad-hoc signed development build may need permissions again after rebuilding. Use the same app copy and restart it after granting access. A green permission label alone does not confirm that button interception is working: test a mapped button on selected text.
+An ad-hoc signed development build needs permissions again after every rebuild, because macOS ties the permission to the exact binary. Reset the stale entries and add the app again:
+
+```bash
+tccutil reset Accessibility com.example.NagaController && tccutil reset ListenEvent com.example.NagaController
+```
+
+A green permission label alone does not confirm that button interception is working: test a mapped button on selected text.
 
 The app does not set up login startup automatically.

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -1,0 +1,59 @@
+# Using NagaController
+
+## Set up the app
+
+1. Open NagaController.
+2. In macOS System Settings, allow the app under Privacy & Security → Accessibility and Input Monitoring.
+3. Quit and reopen the app after granting access.
+4. Click its menu bar icon and enable **Enable remapping (blocks original keys)**.
+5. Open **Configure mappings…**.
+
+Saving a mapping does not turn remapping on. If a button still types a number, check the switch in the menu bar first. If access was just granted, restart the app.
+
+## Assign a shortcut
+
+Select a profile, click **Edit…** on a button, then choose **Key**. Enter a key such as `c` and select the Command modifier for Copy. Save the action, then use the main **Save** button to save your profiles to disk.
+
+The description is only a label. For example, naming an action "Paste" does not make it paste: the shortcut must be Command+V.
+
+## Switch profiles with mouse buttons
+
+This requires the [profile-switch fix](https://github.com/DParent10/NagaController/pull/12). Older builds may save a Profile action without applying it when pressed.
+
+Create your profiles under **Manage Profiles**. Edit a button, choose **Profile**, select the target profile, and save.
+
+For example:
+
+| Button | Target profile |
+| --- | --- |
+| 10 | General |
+| 11 | VS Code |
+| 12 | Codex |
+
+Set these buttons in every profile you want to switch from. They are not global. You can duplicate a profile to keep the same switching buttons.
+
+Switching a profile changes the button mappings; it does not open or focus an application. Automatic switching based on the active application is not implemented.
+
+## DPI buttons and Back/Forward over Bluetooth
+
+On our tested Naga V2 HyperSpeed, mapping DPI Up/Down in NagaController also left the mouse's built-in DPI change active. Blocking the original keys did not prevent the sensitivity change.
+
+This setup worked on that mouse:
+
+1. Connect the mouse to a Windows computer using its 2.4 GHz receiver.
+2. In Razer Synapse, select the DPI buttons and assign Back/Forward under **Mouse Function**. The choices may be named **Mouse Button 4** and **Mouse Button 5**. Test the direction instead of relying on the number.
+3. Quit Synapse and check both buttons again.
+4. Power the mouse off and on, switch to Bluetooth, and test on the Mac.
+5. If Back/Forward works without NagaController, leave DPI Up/Down unassigned in NagaController to avoid duplicate actions.
+
+The user confirmed that the assignments continued to work over Bluetooth on their mouse. This is a tested setup, not a guarantee for every Razer model or firmware version.
+
+Razer's [button mapping instructions](https://mysupport.razer.com/app/answers/detail/a_id/6400/) include a requirement to keep Synapse running. Check the behavior on your own mouse before relying on saved assignments.
+
+## Updates and saved settings
+
+The standard app stores profiles in `~/Library/Application Support/NagaController/profiles.json`. Back up this file before changing builds.
+
+An ad-hoc signed development build may need permissions again after rebuilding. Use the same app copy and restart it after granting access. A green permission label alone does not confirm that button interception is working: test a mapped button on selected text.
+
+The app does not set up login startup automatically.


### PR DESCRIPTION
Add a short user guide covering permissions, the remapping switch, saving shortcuts, and profile buttons.

It also describes a tested Naga V2 HyperSpeed setup: assigning Back/Forward to the DPI buttons in Windows Synapse over 2.4 GHz, then using those assignments over Bluetooth on a Mac. The guide asks users to test this on their own mouse and explains how to avoid duplicate actions.

Profile-button instructions require the fix in #12. The guide links to it and notes that older builds may save a Profile action without applying it.