### PR TITLE
Never learn or match HID status pages as button triggers

### DIFF
--- a/Sources/NagaController/HID/HIDListener.swift
+++ b/Sources/NagaController/HID/HIDListener.swift
@@ -19,6 +19,12 @@ final class HIDListener {
     
     private var learningCallback: ((UInt32, UInt32, IOHIDElementCookie, Int32, Int, Int) -> Void)?
 
+    // Usage pages that carry periodic status values (axes, battery, sensors) rather than
+    // button presses. Never learn them as triggers or match bindings against them; a
+    // Naga V2 HS was seen emitting Sensor-page (0x20) values that got learned as a
+    // trigger and then fired the button on every status update.
+    private static let statusUsagePages: Set<UInt32> = [0x01, 0x06, 0x20, 0x84, 0x85]
+
     private static let whitelistedVendors: Set<Int> = [
         0x1532,
         0x068e
@@ -104,6 +110,7 @@ final class HIDListener {
         // bail out before doing any per-event device property lookups.
         let isMovement = (usagePage == 0x01 && (usage == 0x30 || usage == 0x31 || usage == 0x38))
         if isMovement { return }
+        if HIDListener.statusUsagePages.contains(usagePage) { return }
 
         let device = IOHIDElementGetDevice(element)
         let isLearning = queue.sync { learningCallback != nil }


### PR DESCRIPTION
### What does this PR do?

Found while verifying #8 on a Naga V2 HS over Bluetooth. Clicking **Learn Hardware Trigger…** on the DPI Up card captured a Sensor-page (`usagePage=0x20, usage=0x47f, value=117`) status report from the mouse *before* any button was pressed, saved it as the trigger, and the button then fired on its own on the next periodic status update:

```
[HID] LEARNING: Triggering callback for usagePage=0x20, usage=0x47f, value=117
[HID] LEARNING: Triggering callback for usagePage=0x20, usage=0x47f, value=116
[HID] Mapped press for button 13 (Remapping=true)
[HID] Synthetic press captured for button 13 (raw=0x75)
```

`handle(value:)` now returns early for usage pages that carry periodic status values rather than presses (Generic Desktop `0x01`, Generic Device Controls `0x06`, Sensor `0x20`, Power `0x84`, Battery `0x85`), before both the learning callback and the binding lookup. Keyboard (`0x07`), Button (`0x09`), Consumer (`0x0C`) and the virtual DPI page (`0xFF01`) are unaffected.

### Testing

Builds clean (debug and release, no warnings). The failure was reproduced on hardware; the fix itself is compile-checked only, since each rebuild of the ad-hoc signed app requires re-granting Accessibility and Input Monitoring. Re-learning DPI Up/Down after the fix is the hardware check to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
