### PR TITLE
Open the popover on first launch, with an alert fallback

### DIFF
--- a/Sources/NagaController/AppDelegate.swift
+++ b/Sources/NagaController/AppDelegate.swift
@@ -68,6 +68,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         updateStatusItemBattery(level: BatteryMonitor.shared.batteryLevel)
 
+        // First launch: the app has no window or Dock icon, so open the popover once to
+        // show where it lives. If the status item didn't make it onto the menu bar (a full
+        // menu bar on a notched MacBook hides items), fall back to an alert.
+        let firstLaunchKey = "NagaController.didShowFirstLaunchPopover"
+        if !UserDefaults.standard.bool(forKey: firstLaunchKey) {
+            UserDefaults.standard.set(true, forKey: firstLaunchKey)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                self?.showFirstLaunchHint()
+            }
+        }
+
         // Start event tap based on persisted setting
         let remapEnabled = ConfigManager.shared.getRemappingEnabled()
         eventTapManager.start(listenOnly: !remapEnabled)
@@ -76,6 +87,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         eventTapManager.stop()
         if let profileObserver { NotificationCenter.default.removeObserver(profileObserver) }
+    }
+
+    private func showFirstLaunchHint() {
+        NSApp.activate(ignoringOtherApps: true)
+        if let button = statusItem.button, button.window?.isVisible == true, !popover.isShown {
+            togglePopover(nil)
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = "NagaController runs in the menu bar"
+        alert.informativeText = "There is no window or Dock icon. Look for the mouse icon in the menu bar to enable remapping and configure buttons. If you don't see it, your menu bar may be full; remove or hide a few other items so it fits."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     @objc private func togglePopover(_ sender: Any?) {


### PR DESCRIPTION
### What does this PR do?

Addresses #9 and #11, both "the app doesn't open". NagaController is a menu-bar-only app with no window or Dock icon, and #11 reports no menu bar icon at all while the process is running — on a notched MacBook, macOS hides status items that don't fit.

On first launch (tracked by a `UserDefaults` flag), after a one-second delay:
- if the status item is on screen, activate the app and open the popover once, so the app shows where it lives;
- otherwise show an alert explaining that it runs in the menu bar and that a full menu bar can hide the icon.

### Testing

Builds clean. Hardware/UI check pending: fresh launch shows the popover; subsequent launches don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
