### PR TITLE
Add Navigation presets (arrows, Home/End, Page Up/Down, Forward Delete)

### DIFF
--- a/Sources/NagaController/UI/ActionEditorViewController.swift
+++ b/Sources/NagaController/UI/ActionEditorViewController.swift
@@ -101,6 +101,17 @@ final class ActionEditorViewController: NSViewController {
         ShortcutPreset(name: "Delete (Backspace)", key: "delete", modifiers: [], isHeader: false),
         ShortcutPreset(name: "Space", key: "space", modifiers: [], isHeader: false),
 
+        .header("Navigation"),
+        ShortcutPreset(name: "Left Arrow", key: "left", modifiers: [], isHeader: false),
+        ShortcutPreset(name: "Right Arrow", key: "right", modifiers: [], isHeader: false),
+        ShortcutPreset(name: "Up Arrow", key: "up", modifiers: [], isHeader: false),
+        ShortcutPreset(name: "Down Arrow", key: "down", modifiers: [], isHeader: false),
+        ShortcutPreset(name: "Home", key: "home", modifiers: [], isHeader: false),
+        ShortcutPreset(name: "End", key: "end", modifiers: [], isHeader: false),
+        ShortcutPreset(name: "Page Up", key: "page up", modifiers: [], isHeader: false),
+        ShortcutPreset(name: "Page Down", key: "page down", modifiers: [], isHeader: false),
+        ShortcutPreset(name: "Forward Delete", key: "forward delete", modifiers: [], isHeader: false),
+
         .header("Modifier Keys"),
         ShortcutPreset(name: "Command", key: "command", modifiers: [], isHeader: false),
         ShortcutPreset(name: "Shift", key: "shift", modifiers: [], isHeader: false),


### PR DESCRIPTION
Follow-up to #15, which merged before this commit landed on its branch. Adds a **Navigation** section to the Key tab's Quick Presets so users without those keys, or who never find the capture box, can still map them. Closes the remaining gap in #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)