### PR TITLE
Make the action editor readable in Light mode; give the hardware trigger its own row

### DIFF
--- a/Sources/NagaController/UI/ActionEditorViewController.swift
+++ b/Sources/NagaController/UI/ActionEditorViewController.swift
@@ -160,6 +160,7 @@ final class ActionEditorViewController: NSViewController {
 
     override func loadView() {
         let glassyView = UIStyle.makeGlassyView()
+        glassyView.appearance = NSAppearance(named: .darkAqua)
         self.view = glassyView
         
         let container = NSView()
@@ -379,27 +380,42 @@ final class ActionEditorViewController: NSViewController {
         learnButton.target = self
         learnButton.action = #selector(learnHardwareTapped)
         UIStyle.styleSecondaryButton(learnButton)
-        learnButton.widthAnchor.constraint(equalToConstant: 190).isActive = true
-        learnButton.heightAnchor.constraint(equalToConstant: 28).isActive = true
+        learnButton.widthAnchor.constraint(equalToConstant: 200).isActive = true
+        learnButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        learnButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.16).cgColor
+        learnButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.5).cgColor
         
         clearHardwareButton.target = self
         clearHardwareButton.action = #selector(clearHardwareTapped)
         clearHardwareButton.image = UIStyle.symbol("xmark.circle.fill", size: 14)
         clearHardwareButton.isBordered = false
         
-        hardwareBindingLabel.font = .systemFont(ofSize: 11)
-        hardwareBindingLabel.textColor = NSColor.white.withAlphaComponent(0.3)
-        
-        let hardwareStack = NSStackView(views: [hardwareBindingLabel, learnButton, clearHardwareButton])
+        hardwareBindingLabel.font = .systemFont(ofSize: 12)
+        hardwareBindingLabel.textColor = NSColor.white.withAlphaComponent(0.7)
+        hardwareBindingLabel.lineBreakMode = .byTruncatingTail
+        hardwareBindingLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        // The hardware trigger row gets its own line: sharing the Cancel/Save row left
+        // the "Trigger:" label with no room and it was truncated to nothing.
+        let hardwareCaption = NSTextField(labelWithString: "HARDWARE TRIGGER")
+        hardwareCaption.font = .systemFont(ofSize: 11, weight: .black)
+        hardwareCaption.textColor = NSColor.white.withAlphaComponent(0.3)
+        let hardwareStack = NSStackView(views: [learnButton, clearHardwareButton, hardwareBindingLabel, NSView()])
         hardwareStack.spacing = 10
         hardwareStack.alignment = .centerY
+        let hardwareRow = NSStackView(views: [hardwareCaption, hardwareStack])
+        hardwareRow.orientation = .vertical
+        hardwareRow.alignment = .leading
+        hardwareRow.spacing = 8
+        hardwareStack.widthAnchor.constraint(equalTo: hardwareRow.widthAnchor).isActive = true
 
-        buttonsStack.addArrangedSubview(hardwareStack)
         buttonsStack.addArrangedSubview(NSView()) // Spacer
         buttonsStack.addArrangedSubview(cancelButton)
         buttonsStack.addArrangedSubview(saveButton)
 
         container.addSubview(header)
+        container.addSubview(hardwareRow)
+        hardwareRow.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(layerSegmented)
         container.addSubview(segmented)
         container.addSubview(descStack)
@@ -426,7 +442,11 @@ final class ActionEditorViewController: NSViewController {
             contentStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 32),
             contentStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -32),
 
-            buttonsStack.topAnchor.constraint(greaterThanOrEqualTo: contentStack.bottomAnchor, constant: 32),
+            hardwareRow.topAnchor.constraint(greaterThanOrEqualTo: contentStack.bottomAnchor, constant: 24),
+            hardwareRow.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 32),
+            hardwareRow.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -32),
+
+            buttonsStack.topAnchor.constraint(equalTo: hardwareRow.bottomAnchor, constant: 20),
             buttonsStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 32),
             buttonsStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -32),
             buttonsStack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -32),

--- a/Sources/NagaController/UI/MappingWindowController.swift
+++ b/Sources/NagaController/UI/MappingWindowController.swift
@@ -7,6 +7,11 @@ final class MappingWindowController: NSWindowController, NSWindowDelegate {
     private init() {
         let vc = MappingViewController()
         let window = NSWindow(contentViewController: vc)
+        // The mapping UI and the action editor sheet are styled for a dark background
+        // (white labels on glass). Sheets inherit the window's appearance, not the
+        // content view's, so pin the window itself or the editor goes unreadable in
+        // Light mode.
+        window.appearance = NSAppearance(named: .darkAqua)
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.title = "NagaController — Button Mappings"
         window.titleVisibility = .hidden


### PR DESCRIPTION
### What does this PR do?

Two editor readability problems found while testing on hardware today.

**Light mode made the editor unreadable.** The editor is styled for a dark background (white labels on a HUD material), but a sheet inherits its *window's* appearance, not the content view's. `MappingViewController` pins `darkAqua` on its own view, which doesn't reach the sheet, so with the system in Light mode the whole editor rendered light and the Label caption, group titles, hardware trigger row, Learn button and Cancel were all nearly invisible. The mapping window is now pinned to `darkAqua` (sheets inherit it) and the editor view is pinned too.

**The Trigger label was truncated to nothing.** The hardware trigger controls shared the Cancel/Save row; with the label, Learn button, clear button and two 100pt buttons in 476pt, the label lost. They now sit on their own captioned **HARDWARE TRIGGER** row above Cancel/Save, with the label at readable contrast and the Learn button's fill/border stronger.

### Testing

Verified in the running app in Light mode: editor is dark with all text readable, the DPI Up card shows `Trigger: KeyCode 0x69`, Learn button legible. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
