### PR TITLE
Release v0.2.0: version bump and DMG script cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A macOS menu bar app to remap the 12 side buttons of the Razer Naga V2 Hyperspeed. Intercepts the default 1–0–=– key events and maps them to actions like key sequences, app launching, and macros. Includes Bluetooth battery level display.
 
-**[⬇️ Download Latest Release (v0.1.0)](https://github.com/DParent10/NagaController/releases/latest)**
+**[⬇️ Download Latest Release (v0.2.0)](https://github.com/DParent10/NagaController/releases/latest)**
 
 ## Features
 
@@ -26,7 +26,7 @@ A macOS menu bar app to remap the 12 side buttons of the Razer Naga V2 Hyperspee
 
 ## Installation
 
-1. Download `NagaController-v0.1.0.dmg` from [Releases](https://github.com/DParent10/NagaController/releases/latest)
+1. Download `NagaController-v0.2.0.dmg` from [Releases](https://github.com/DParent10/NagaController/releases/latest)
 2. Open the DMG file
 3. Drag `NagaController.app` to the Applications folder
 4. Double-click `NagaController.app` to launch

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/SETUP-INSTRUCTIONS.md
+++ b/SETUP-INSTRUCTIONS.md
@@ -39,7 +39,7 @@ This will:
 
 ```bash
 # Mount the DMG
-open NagaController-v0.1.0.dmg
+open NagaController-v0.2.0.dmg
 ```
 
 You should see:
@@ -81,7 +81,7 @@ create-dmg \
   --icon-size 160 \
   --icon "NagaController.app" 180 170 \
   --app-drop-link 480 170 \
-  "NagaController-v0.1.0.dmg" \
+  "NagaController-v0.2.0.dmg" \
   "NagaController.app"
 ```
 
@@ -89,13 +89,13 @@ create-dmg \
 
 ```bash
 # Sign DMG
-codesign --sign "Developer ID Application: Devin Parent (SUT6Y24T2J)" NagaController-v0.1.0.dmg
+codesign --sign "Developer ID Application: Devin Parent (SUT6Y24T2J)" NagaController-v0.2.0.dmg
 
 # Notarize
-xcrun notarytool submit NagaController-v0.1.0.dmg --keychain-profile "notary-profile" --wait
+xcrun notarytool submit NagaController-v0.2.0.dmg --keychain-profile "notary-profile" --wait
 
 # Staple
-xcrun stapler staple NagaController-v0.1.0.dmg
+xcrun stapler staple NagaController-v0.2.0.dmg
 ```
 
 ## Result:

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -56,7 +56,7 @@ else
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
+  <string>0.2.0</string>
   <key>CFBundleVersion</key>
   <string>1</string>
   <key>LSMinimumSystemVersion</key>

--- a/dmg-assets/setup-app-icon-and-dmg-simple.sh
+++ b/dmg-assets/setup-app-icon-and-dmg-simple.sh
@@ -10,6 +10,9 @@ echo "🎨 Setting up NagaController icon and DMG background..."
 # Get the project root (parent of dmg-assets)
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_BUNDLE="$PROJECT_ROOT/NagaController.app"
+# Release version comes from the built app so this script never needs editing per release
+VERSION="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || echo 0.0.0)"
+DMG_PATH="$PROJECT_ROOT/NagaController-v${VERSION}.dmg"
 
 # Check if app bundle exists
 if [ ! -d "$APP_BUNDLE" ]; then
@@ -68,7 +71,7 @@ echo "🎨 Creating DMG with custom background..."
 codesign --force --deep --sign "Developer ID Application: Devin Parent (SUT6Y24T2J)" --options runtime "$APP_BUNDLE"
 
 # Remove old DMG if exists
-rm -f "$PROJECT_ROOT/NagaController-v0.1.0.dmg"
+rm -f "$DMG_PATH"
 
 # Create DMG
 create-dmg \
@@ -82,13 +85,13 @@ create-dmg \
   --hide-extension "NagaController.app" \
   --app-drop-link 480 170 \
   --no-internet-enable \
-  "$PROJECT_ROOT/NagaController-v0.1.0.dmg" \
+  "$DMG_PATH" \
   "$APP_BUNDLE" || {
     echo "Note: create-dmg may show errors but often succeeds anyway"
   }
 
 # Check if DMG was created
-if [ ! -f "$PROJECT_ROOT/NagaController-v0.1.0.dmg" ]; then
+if [ ! -f "$DMG_PATH" ]; then
     echo "❌ DMG creation failed"
     exit 1
 fi
@@ -98,17 +101,17 @@ echo ""
 echo "🔐 Signing and notarizing DMG..."
 
 # Sign the DMG
-codesign --sign "Developer ID Application: Devin Parent (SUT6Y24T2J)" "$PROJECT_ROOT/NagaController-v0.1.0.dmg"
+codesign --sign "Developer ID Application: Devin Parent (SUT6Y24T2J)" "$DMG_PATH"
 
 # Notarize the DMG
 echo "Submitting for notarization (this may take a few minutes)..."
-xcrun notarytool submit "$PROJECT_ROOT/NagaController-v0.1.0.dmg" --keychain-profile "notary-profile" --wait
+xcrun notarytool submit "$DMG_PATH" --keychain-profile "notary-profile" --wait
 
 # Staple the notarization
-xcrun stapler staple "$PROJECT_ROOT/NagaController-v0.1.0.dmg"
+xcrun stapler staple "$DMG_PATH"
 
 echo ""
 echo "✅ Done! Your signed and notarized DMG is ready:"
-echo "   📦 $PROJECT_ROOT/NagaController-v0.1.0.dmg"
+echo "   📦 $DMG_PATH"
 echo ""
-echo "Test it: open NagaController-v0.1.0.dmg"
+echo "Test it: open $DMG_PATH"


### PR DESCRIPTION
Bumps the app to **0.2.0** (build 2) and makes the DMG/notarization script read the version from the built app's Info.plist instead of hardcoding `v0.1.0` in eight places. README and SETUP-INSTRUCTIONS updated to the new DMG name.

Merge this before tagging `v0.2.0`. Release notes are drafted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)